### PR TITLE
allow the product be published or not at creation

### DIFF
--- a/src/components/sellerPages/inventory/index.js
+++ b/src/components/sellerPages/inventory/index.js
@@ -20,11 +20,13 @@ function Inventory({ addProduct, addItemImage }) {
   const [photo, setPhoto] = useState(
     "http://superprosamui.com/2016/wp-content/plugins/ap_background/images/default/default_large.png"
   );
+  const [published, setPublished] = useState(true);
+
   const formConsolidate = async () => {
     let completeObject = {
       item: {
         ...mainInfo,
-        published: true
+        published
       },
       spec: {
         ...specForm
@@ -74,6 +76,7 @@ function Inventory({ addProduct, addItemImage }) {
               mainInfo={mainInfo}
               specForm={specForm}
               photo={photo}
+              setPublished={setPublished}
             />
           </Carousel>
         </div>

--- a/src/components/sellerPages/inventory/inventoryStyles.css
+++ b/src/components/sellerPages/inventory/inventoryStyles.css
@@ -33,3 +33,16 @@ h1 {
 .supplement-detail{
     color: lightgray;
 }
+.product-container {
+    flex-direction: column;
+}
+.product-container .ant-typography strong{
+    display: flex;
+    align-items: center;
+    margin-bottom: 20px;
+}
+.product-container button {
+    min-width: 80px;
+    margin-left: 5px;
+}
+

--- a/src/components/sellerPages/inventory/newItem/newProductInfo.js
+++ b/src/components/sellerPages/inventory/newItem/newProductInfo.js
@@ -1,41 +1,54 @@
 import { useOktaAuth } from "@okta/okta-react";
 import React, { useEffect, useState } from "react";
-import { Rate, Avatar, Tag } from "antd";
+import { Rate, Avatar, Tag, Switch, Typography } from "antd";
 import { GlobalOutlined } from "@ant-design/icons";
 
-const NewProductInfo = ({ photo, mainInfo, specForm }) => {
-  let dollars = mainInfo.price;
+const NewProductInfo = ({ photo, mainInfo, specForm, setPublished }) => {
+  let dollars = mainInfo.price_in_cents;
+  let { Text } = Typography;
+  const [switchButton, setSwitchButton] = useState(true);
 
+  let switchText = {
+    publish:
+      "This Product will be saved and will be published to the site right away",
+    hide:
+      "This Product will be saved but it wont be published right now, you can publish it later"
+  };
+
+  function onChangeSwitch(checked) {
+    setPublished(checked);
+    setSwitchButton(checked);
+  }
   return (
     <div className="product-page">
       <div className="product-container">
+        <Text strong>
+          {switchButton ? switchText.publish : switchText.hide}
+          <Switch
+            defaultChecked
+            checkedChildren="Publish"
+            unCheckedChildren="Hide it"
+            onChange={onChangeSwitch}
+          />
+        </Text>
         <div>
           <img src={photo} />
         </div>
 
         <div className="item">
           <div className="name-price">
-            <p>{mainInfo.name}</p>
-            <p>${dollars}</p>
+            <p>{mainInfo.item_name}</p>
           </div>
-          <div className="rating">
-            <Rate />
-          </div>
-          <div className="store-name">
-            <Avatar size="small" icon={<GlobalOutlined />} />
-            <h3>Store Name</h3>
-          </div>
-          <p>location</p>
           <section>
             <p>{mainInfo.description}</p>
             {mainInfo.quantity_available !== 0 ? (
-              <h2 style={{ color: "green" }}>
+              <h3 style={{ color: "green" }}>
                 QTY: {mainInfo.quantity_available}
-              </h2>
+              </h3>
             ) : (
-              <h2 style={{ color: "red" }}>
+              <h3 style={{ color: "red" }}>
                 QTY: {mainInfo.quantity_available}
-              </h2>
+              </h3>
             )}
           </section>
         </div>

--- a/src/components/sellerPages/inventory/newItem/review_product.js
+++ b/src/components/sellerPages/inventory/newItem/review_product.js
@@ -6,9 +6,10 @@ function Finalize({
   setProgress,
   slider,
   formConsolidate,
-  photo,
   mainInfo,
-  specForm
+  specForm,
+  photo,
+  setPublished
 }) {
   const formConfirm = async () => {
     await formConsolidate();
@@ -17,10 +18,10 @@ function Finalize({
   return (
     <div className="contents">
       <NewProductInfo
-        item={""}
         photo={photo}
         mainInfo={mainInfo}
         specForm={specForm}
+        setPublished={setPublished}
       />
       <FormButton
         setProgress={setProgress}


### PR DESCRIPTION
## Motivation 
give the seller the option of saving products that won't be able to purchase yet, but eventually, they will
## What you did
using a switch component from ant Design change the value of published variable that will be sent to DB to be stored on item table
## TRELLO CARD

![image](https://user-images.githubusercontent.com/33973377/106824771-7e2a0800-6651-11eb-8881-e518b5198afa.png)

## USER STORY

User Storie: As a seller, I can add items to my inventory and allow them to be on sale or not (hide the product from the buyer)
this particular PR is aiming for the second part of the User Storie

## TESTS
Not tested yet, still on development

